### PR TITLE
changes on how to handle gps AT commands

### DIFF
--- a/DFRobot_sim808.h
+++ b/DFRobot_sim808.h
@@ -64,10 +64,11 @@ public:
      *  @return true if connected, false otherwise
      */
 
-    bool init(void);
+    bool init(boolean simcheck = true);
 
    
     /** check if DFRobot_SIM808 module is powered on or not
+     *  @param  simcheck checks if SIM is OK, (GPS works without SIM)
      *  @returns
      *      true on success
      *      false on error
@@ -326,7 +327,10 @@ public:
 	//Open or Close GPS
 	bool  attachGPS();
 	bool  detachGPS();
-	
+	bool  getGPS();
+
+    // set GPS test node
+    bool setTestGPS(bool test);
      // Parse a (potentially negative) number with up to 2 decimal digits -xxxx.yy
 	 
 	void getTime(uint32_t time);
@@ -340,7 +344,7 @@ public:
 	bool  getGPRMC();
 	
 	//get GPS signal
-	bool  getGPS(); 
+	bool  getGPSTestData(); 
 	
 	
 	 SoftwareSerial *gprsSerial;
@@ -361,20 +365,34 @@ public:
 		float speed_kph;
 		float heading;
 		float altitude;
-	}GPSdata;
+	} GPSdata;
+
+    struct gspstatus {
+        uint8_t status;
+        uint8_t sat_in_view;
+        uint8_t sat_used;
+        uint8_t sat_glonass;
+        //<HDOP>,<PDOP>, <VDOP>
+        float horizontal_pres;
+        float position_pres;
+        float vertical_pres;
+    } GPSStatus;
 
     struct DMSData{
         int degrees;
         int minutes;
-        float seconeds;
+        float seconds;
     }latDMS,longDMS;
+    char cgnsinf[128];
 
 private:
+
 	byte serialFlag;
     bool checkSIMStatus(void);
     uint32_t str_to_ip(const char* str);
     static DFRobot_SIM808* inst;
     uint32_t _ip;
     char ip_string[16]; //XXX.YYY.ZZZ.WWW + \0
+    char *strtok_new(char * string, char const * delimiter);
 };
 #endif

--- a/SIM808_QueryGPS/SIM808_QueryGPS.ino
+++ b/SIM808_QueryGPS/SIM808_QueryGPS.ino
@@ -1,0 +1,115 @@
+/*
+### Get GPS data
+1. This example is used to test SIM808 GPS/GPRS/GSM Shield's reading GPS data.
+2. Open the SIM808_GetGPS example or copy these code to your project
+3. Download and dial the function switch to Arduino
+4. open serial helper
+4. Place it outside, waiting for a few minutes and then it will send GPS data to serial
+
+create on 2016/09/23, version: 1.0
+by jason
+
+*/
+#include <DFRobot_sim808.h>
+#include <SoftwareSerial.h>
+
+// Arduino Uno Wifi Rev2
+#define PIN_TX    1
+#define PIN_RX    0
+SoftwareSerial simSerial(PIN_TX,PIN_RX);
+DFRobot_SIM808 sim808(&simSerial);//Connect RX,TX,PWR,
+
+//DFRobot_SIM808 sim808(&Serial);
+
+void setup() {
+  // Arduino Uno Wifi Rev2 has a hardware Serial
+  // and talks to the dfrobot board using digital pins 0,1
+  simSerial.begin(9600);
+  Serial.begin(9600);
+
+  //******** Initialize sim808 module *************
+  while(!sim808.init(false)) { 
+      delay(1000);
+      Serial.print("Sim808 init error\r\n");
+  }
+
+  //************* Turn on the GPS power************
+  if( sim808.attachGPS())
+      Serial.println("Open the GPS power success");
+  else 
+      Serial.println("Open the GPS power failure");
+  
+}
+
+void loop() {
+      Serial.println("\n\n");
+   //************** Get GPS data *******************
+
+   if (sim808.getGPS()) {
+    Serial.print(sim808.GPSdata.year);
+    Serial.print("/");
+    Serial.print(sim808.GPSdata.month);
+    Serial.print("/");
+    Serial.print(sim808.GPSdata.day);
+    Serial.print(" ");
+    Serial.print(sim808.GPSdata.hour);
+    Serial.print(":");
+    Serial.print(sim808.GPSdata.minute);
+    Serial.print(":");
+    Serial.print(sim808.GPSdata.second);
+    Serial.print(":");
+    Serial.println(sim808.GPSdata.centisecond);
+    
+    Serial.print("latitude :");
+    Serial.println(sim808.GPSdata.lat,6);
+    
+    sim808.latitudeConverToDMS();
+    Serial.print("latitude :");
+    Serial.print(sim808.latDMS.degrees);
+    Serial.print(167);
+    Serial.print(sim808.latDMS.minutes);
+    Serial.print("\'");
+    Serial.print(sim808.latDMS.seconds,6);
+    Serial.println("\"");
+    Serial.print("longitude :");
+    Serial.println(sim808.GPSdata.lon,6);
+    sim808.LongitudeConverToDMS();
+    Serial.print("longitude :");
+    Serial.print(sim808.longDMS.degrees);
+    Serial.print(167);
+    Serial.print(sim808.longDMS.minutes);
+    Serial.print("\'");
+    Serial.print(sim808.longDMS.seconds,6);
+    Serial.println("\"");
+    
+    Serial.print("speed_kph :");
+    Serial.println(sim808.GPSdata.speed_kph);
+    Serial.print("heading :");
+    Serial.println(sim808.GPSdata.heading);
+
+    Serial.print("pressions (h,v,p):");
+    Serial.print(sim808.GPSStatus.horizontal_pres);
+    Serial.print(",");
+    Serial.print(sim808.GPSStatus.vertical_pres);
+    Serial.print(",");
+    Serial.println(sim808.GPSStatus.position_pres);
+
+    Serial.print("satellites (inview, used, Glonass):");
+    Serial.print(sim808.GPSStatus.sat_in_view);
+    Serial.print(",");
+    Serial.print(sim808.GPSStatus.sat_used);
+    Serial.print(",");
+    Serial.println(sim808.GPSStatus.sat_glonass);
+
+    Serial.print("CGNSINF:");
+    for (int i=0; i < sizeof(sim808.cgnsinf)-1; i++)  {
+        if (sim808.cgnsinf[i]<32) sim808.cgnsinf[i] = ' ';
+    }
+    Serial.println(sim808.cgnsinf);
+
+  } else {
+    Serial.println("getGPS failed");
+    delay(1000);
+  }
+
+}


### PR DESCRIPTION
I have been trying to get your library to work, Here are some issues I found that might be helpful to somebody:

The GPS on the sim808 works without SIM. However, the init function returns false / error if there is no SIM. Minor issue, but would have been nice to know.

The GPS data is accessed by putting the chip on test mode.
```

bool DFRobot_SIM808::attachGPS()
{
  Serial.println("DFRobot_SIM808::attachGPS");
	 if(!sim808_check_with_cmd("AT+CGNSPWR=1\r\n", "OK\r\n", CMD)) { 
        return false;
    }
	 if(!sim808_check_with_cmd("AT+CGNSTST=1\r\n", "OK\r\n", CMD)) { 
        return false;
    }
	return true;
}
```
this floods the serial port with a lot of information, so a small serial buffer is likely to overflow (arduino's default is 64 Bytes), so function getGPS() will likely overflow between calls, and never return anything. For this to work, the getGPS() function MUST be called before the serial overflows.

I don't see the point in putting the chip in TEST mode to access functionality that i think should be accessed by using (AT+CGNSINF) instead.

the parse functions, don't work with the string returned by AT+CGNSINF as the format is slightly different.

So, Renamed 
bool DFRobot_SIM808::getGPS()  to bool DFRobot_SIM808::getGPSTestData()

Created function  DFRobot_SIM808::getGPS() (body) that uses the on demand poll of data

